### PR TITLE
implemented tekton chain transparent signature and attestation

### DIFF
--- a/battalion-apps/bubble-app/bubble-pipeline.yaml
+++ b/battalion-apps/bubble-app/bubble-pipeline.yaml
@@ -176,6 +176,34 @@ spec:
       workspaces:
         - name: workspace
           workspace: source
+    - name: generate-sbom
+      taskRef:
+        name: generate-sbom
+      workspaces:
+        - name: source
+          workspace: source
+      runAfter:
+        - build-image
+      params:
+        - name: IMAGETOSCAN
+          value: "$(tasks.build-image.results.IMAGE_URL)@$(tasks.build-image.results.IMAGE_DIGEST)"
+        - name: SBOMFILE
+          value: "$(workspaces.source.path)/sbom.cdx"
+        - name: TLSVERIFY
+          value: "false"
+        - name: OUTPUT_IMAGE
+          value: "image-registry.openshift-image-registry.svc:5000/demo-cicd/bgd:sbom"
+    - name: vuln-scan
+      taskRef:
+        name: vulnerability-sbom
+      workspaces:
+        - name: source
+          workspace: source
+      runAfter:
+        - generate-sbom
+      params:
+        - name: SBOM
+          value: "$(workspaces.source.path)/sbom.cdx"
     - name: skopeo-copy
       params:
         - name: srcImageURL
@@ -227,6 +255,25 @@ spec:
           value: 'true'
       runAfter:
         - build-image
+      taskRef:
+        kind: ClusterTask
+        name: skopeo-copy
+      workspaces:
+        - name: images-url
+          workspace: source
+    - name: skopeo-copy-sbom
+      params:
+        - name: srcImageURL
+          value: >-
+            docker://image-registry.openshift-image-registry.svc:5000/demo-cicd/bgd:sbom
+        - name: destImageURL
+          value: 'docker://quay.io/wael2000/bgd:$(params.battalion)-sbom'
+        - name: srcTLSverify
+          value: 'true'
+        - name: destTLSverify
+          value: 'true'
+      runAfter:
+        - generate-sbom
       taskRef:
         kind: ClusterTask
         name: skopeo-copy

--- a/battalion-apps/bubble-app/bubble-pipeline.yaml
+++ b/battalion-apps/bubble-app/bubble-pipeline.yaml
@@ -76,8 +76,8 @@ spec:
       runAfter:
         - code-analysis
       taskRef:
-        kind: ClusterTask
-        name: s2i-java
+        kind: Task
+        name: s2i-java-chains
       workspaces:
         - name: source
           workspace: source
@@ -183,6 +183,44 @@ spec:
             docker://image-registry.openshift-image-registry.svc:5000/demo-cicd/bgd:$(params.battalion)
         - name: destImageURL
           value: 'docker://quay.io/wael2000/bgd:$(params.battalion)'
+        - name: srcTLSverify
+          value: 'true'
+        - name: destTLSverify
+          value: 'true'
+      runAfter:
+        - build-image
+      taskRef:
+        kind: ClusterTask
+        name: skopeo-copy
+      workspaces:
+        - name: images-url
+          workspace: source
+    - name: skopeo-copy-sig
+      params:
+        - name: srcImageURL
+          value: >-
+            docker://image-registry.openshift-image-registry.svc:5000/demo-cicd/bgd:sha256-$(tasks.build-image.results.SIMPLE_DIGEST).sig
+        - name: destImageURL
+          value: 'docker://quay.io/wael2000/bgd:sha256-$(tasks.build-image.results.SIMPLE_DIGEST).sig'
+        - name: srcTLSverify
+          value: 'true'
+        - name: destTLSverify
+          value: 'true'
+      runAfter:
+        - build-image
+      taskRef:
+        kind: ClusterTask
+        name: skopeo-copy
+      workspaces:
+        - name: images-url
+          workspace: source
+    - name: skopeo-copy-att
+      params:
+        - name: srcImageURL
+          value: >-
+            docker://image-registry.openshift-image-registry.svc:5000/demo-cicd/bgd:sha256-$(tasks.build-image.results.SIMPLE_DIGEST).att
+        - name: destImageURL
+          value: 'docker://quay.io/wael2000/bgd:sha256-$(tasks.build-image.results.SIMPLE_DIGEST).att'
         - name: srcTLSverify
           value: 'true'
         - name: destTLSverify

--- a/battalion-apps/tasks/generate_sbom_task.yaml
+++ b/battalion-apps/tasks/generate_sbom_task.yaml
@@ -1,0 +1,100 @@
+# Tekton task to generate sbom with syft
+# Author: Giuseppe Magnotta <giuseppe.magnotta@gmail.com>
+# Version 0.1
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: generate-sbom
+spec:
+  description: Generate Sbom with syft
+  params:
+    - name: IMAGE
+      default: 'docker.io/anchore/syft@sha256:803d8af5b740fbaa75bd780b947d32721148f8464efbee9b656bb5f2a5dcf176'
+      type: string
+    - name: IMAGETOSCAN
+      type: string
+    - name: SBOMFILE
+      default: 'result.cdx'
+      type: string
+    - name: BUILDAH_IMAGE
+      default: 'quay.io/buildah/stable:latest'
+      description: The location of the buildah builder image.
+      type: string
+    - name: BUILDAH_PARAMS
+      default: "--storage-driver=overlay"
+      description: Parameters to pass to buildah
+      type: string
+    - name: OUTPUT_IMAGE
+      description: Location of the repo where image has to be pushed
+      type: string
+    - name: TLSVERIFY
+      default: 'true'
+      description: >-
+        Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+        registry)
+      type: string
+  results:
+    - description: Url of the image just built.
+      name: IMAGE_URL
+      type: string
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built.
+      type: string
+  volumes:
+    - emptyDir: {}
+      name: varlibcontainers
+  workspaces:
+    - name: source
+    - description: >-
+        An optional workspace that allows providing a .docker/config.json file
+        for Buildah to access the container registry. The file should be placed
+        at the root of the Workspace with name config.json.
+      name: dockerconfig
+      optional: true
+  steps:
+    - name: generate-sbom
+      image: $(params.IMAGE)
+      resources: {}
+      args: ["$(params.IMAGETOSCAN)", "-o", "syft-table", "-o", "cyclonedx-json=$(params.SBOMFILE)"]
+    - name: build-and-push
+      resources: {}
+      image: $(params.BUILDAH_IMAGE)
+      script: |
+        #!/usr/bin/env bash
+
+        set -eu -o pipefail
+
+        OUTPUT_IMAGE=$(params.OUTPUT_IMAGE)
+        TLSVERIFY=$(params.TLSVERIFY)
+        BUILDAH_PARAMS=$(params.BUILDAH_PARAMS)
+
+        builder=$(buildah $BUILDAH_PARAMS from --tls-verify=$TLSVERIFY scratch)
+
+        echo "Copy from $(params.SBOMFILE) to /"
+        buildah $BUILDAH_PARAMS add --chown 0:0 $builder $(params.SBOMFILE) /
+
+        echo "Committing image $OUTPUT_IMAGE"
+        buildah $BUILDAH_PARAMS commit $builder $OUTPUT_IMAGE
+
+        echo "Deleting temporary images"
+        buildah $BUILDAH_PARAMS rm $builder
+
+        [[ "$(workspaces.dockerconfig.bound)" == "true" ]] && export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
+
+        buildah push $BUILDAH_PARAMS --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/sbom-image-digest $OUTPUT_IMAGE \
+          docker://$OUTPUT_IMAGE
+        
+        DIGEST=$(cat $(workspaces.source.path)/sbom-image-digest)
+
+        echo -n "$OUTPUT_IMAGE" > $(results.IMAGE_URL.path)
+        echo -n "$DIGEST" > $(results.IMAGE_DIGEST.path)
+
+        echo -n "Successfully built image $OUTPUT_IMAGE@$DIGEST"
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers

--- a/battalion-apps/tasks/s2i_java_chains.yaml
+++ b/battalion-apps/tasks/s2i_java_chains.yaml
@@ -1,0 +1,138 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/displayName: s2i java teckton chains
+    tekton.dev/pipelines.minVersion: '0.19'
+    tekton.dev/tags: 's2i, java, workspace'
+  name: s2i-java-chains
+  labels:
+    app.kubernetes.io/version: '0.1'
+    operator.tekton.dev/operand-name: openshift-pipelines-addons
+    operator.tekton.dev/provider-type: redhat
+spec:
+  description: s2i-java-chains task clones a Git repository and builds and pushes a container image using S2I and a Java builder image.
+  params:
+    - default: latest
+      description: The tag of java imagestream for java version
+      name: VERSION
+      type: string
+    - default: .
+      description: The location of the path to run s2i from
+      name: PATH_CONTEXT
+      type: string
+    - default: 'true'
+      description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+      name: TLSVERIFY
+      type: string
+    - default: ''
+      description: Additional Maven arguments
+      name: MAVEN_ARGS_APPEND
+      type: string
+    - default: 'false'
+      description: Remove the Maven repository after the artifact is built
+      name: MAVEN_CLEAR_REPO
+      type: string
+    - default: ''
+      description: The base URL of a mirror used for retrieving artifacts
+      name: MAVEN_MIRROR_URL
+      type: string
+    - description: Location of the repo where image has to be pushed
+      name: IMAGE
+      type: string
+    - default: 'registry.redhat.io/rhel8/buildah@sha256:b48f410efa0ff8ab0db6ead420a5d8d866d64af846fece5efb185230d7ecf591'
+      description: The location of the buildah builder image.
+      name: BUILDER_IMAGE
+      type: string
+    - default: 'false'
+      description: Skip pushing the built image
+      name: SKIP_PUSH
+      type: string
+    - default: []
+      description: Environment variables to set during _build-time_.
+      name: ENV_VARS
+      type: array
+  results:
+    - description: Digest of the image just built.
+      name: IMAGE_DIGEST
+      type: string
+    - description: Simple Digest of the image just built withouth sha256
+      name: SIMPLE_DIGEST
+      type: string
+    - description: Url of the image just built.
+      name: IMAGE_URL
+      type: string
+  steps:
+    - args:
+        - '$(params.ENV_VARS[*])'
+      env:
+        - name: HOME
+          value: /tekton/home
+      image: 'registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4'
+      name: generate
+      resources: {}
+      script: |
+        echo "MAVEN_CLEAR_REPO=$(params.MAVEN_CLEAR_REPO)" > /env-vars/env-file
+
+        [[ '$(params.MAVEN_ARGS_APPEND)' != "" ]] &&
+          echo "MAVEN_ARGS_APPEND=$(params.MAVEN_ARGS_APPEND)" >> /env-vars/env-file
+
+        [[ '$(params.MAVEN_MIRROR_URL)' != "" ]] &&
+          echo "MAVEN_MIRROR_URL=$(params.MAVEN_MIRROR_URL)" >> /env-vars/env-file
+
+        echo "Processing Build Environment Variables"
+        for var in "$@"
+        do
+          echo "$var" >> /env-vars/env-file
+        done
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/java:$(params.VERSION) \
+        --image-scripts-url image:///usr/local/s2i \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
+      volumeMounts:
+        - mountPath: /gen-source
+          name: gen-source
+        - mountPath: /env-vars
+          name: env-vars
+      workingDir: $(workspaces.source.path)
+    - image: $(params.BUILDER_IMAGE)
+      name: build-and-push
+      resources: {}
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        [[ "$(workspaces.dockerconfig.bound)" == "true" ]] && export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+
+        echo -n "$(params.IMAGE)" > $(results.IMAGE_URL.path)
+
+        cat $(workspaces.source.path)/image-digest | cut -d ':' -f 2 | tr -d '\n' > $(results.SIMPLE_DIGEST.path)
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+        - mountPath: /gen-source
+          name: gen-source
+      workingDir: /gen-source
+  volumes:
+    - emptyDir: {}
+      name: varlibcontainers
+    - emptyDir: {}
+      name: gen-source
+    - emptyDir: {}
+      name: env-vars
+  workspaces:
+    - mountPath: /workspace/source
+      name: source
+    - description: An optional workspace that allows providing a .docker/config.json file for Buildah to access the container registry. The file should be placed at the root of the Workspace with name config.json.
+      name: dockerconfig
+      optional: true

--- a/battalion-apps/tasks/vulnerability_sbom_task.yaml
+++ b/battalion-apps/tasks/vulnerability_sbom_task.yaml
@@ -1,0 +1,23 @@
+# Tekton task to perform vulnerability scan via grype
+# Author: Giuseppe Magnotta <giuseppe.magnotta@gmail.com>
+# Version 0.1
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: vulnerability-sbom
+spec:
+  description: Perform vulnerability scan via grype on sbom file
+  params:
+    - name: IMAGE
+      default: 'quay.io/gmagnotta/grype-with-db:20230103'
+      type: string
+    - name: SBOM
+      default: 'result.cdx'
+      type: string
+  workspaces:
+    - name: source
+  steps:
+    - name: vulnerability-scan
+      image: $(params.IMAGE)
+      resources: {}
+      args: ["$(params.SBOM)"]


### PR DESCRIPTION
Hi,

I copied-and-pasted the s2i-java task from OCP in order to expose IMAGE_DIGEST and IMAGE_URL monitored by tekton chains in order to perform transparent signature and attestation.

Then I modified the bubble-pipeline in order to use this custom task and extended it in order to export to remote container repository also the .sig and .att tags.

This will allow to have a secure build pipeline that provide provenance and tamper proof capabilites